### PR TITLE
Provide params as inputs to modules and subworkflows instead of direct reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ The `mags`/`bins` workflow requires databases for completeness/contamination est
 
 ### Optional parameters:
 
-| Parameter           | Description                                                                              |
-| ------------------- | ---------------------------------------------------------------------------------------- |
-| `--upload_tpa`      | Flag to control the type of assembly study (third party assembly or not). Default: false |
-| `--test_upload`     | Upload to TEST ENA server instead of LIVE. Default: true                                 |
-| `--webincli_submit` | If set to false, submissions will be validated, but not submitted. Default: true         |
+| Parameter         | Description                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| `--upload_tpa`    | Flag to control the type of assembly study (third party assembly or not). Default: false |
+| `--test_upload`   | Upload to TEST ENA server instead of LIVE. Default: true                                 |
+| `--webincli_mode` | Choose Webin-CLI mode: `submit` or `validate`. Default: `submit`                         |
 
 General command template:
 
@@ -168,7 +168,7 @@ nextflow run nf-core/seqsubmit \
    --outdir <outdir>
 ```
 
-Validation run (submission to the ENA TEST server) in `mags` mode:
+Test run (submission to the ENA TEST server) in `mags` mode:
 
 ```bash
 nextflow run nf-core/seqsubmit \
@@ -177,12 +177,12 @@ nextflow run nf-core/seqsubmit \
    --input assets/samplesheet_genomes.csv \
    --submission_study <your_study> \
    --centre_name TEST_CENTER \
-   --webincli_submit true \
+   --webincli_mode submit \
    --test_upload true \
    --outdir results/validate_mags
 ```
 
-Validation run (submission to the ENA TEST server) in `metagenomic_assemblies` mode:
+Test run (submission to the ENA TEST server) in `metagenomic_assemblies` mode:
 
 ```bash
 nextflow run nf-core/seqsubmit \
@@ -191,7 +191,7 @@ nextflow run nf-core/seqsubmit \
    --input assets/samplesheet_assembly.csv \
    --submission_study <your_study> \
    --centre_name TEST_CENTER \
-   --webincli_submit true \
+   --webincli_mode submit \
    --test_upload true \
    --outdir results/validate_assemblies
 ```
@@ -205,7 +205,7 @@ nextflow run nf-core/seqsubmit \
    --input assets/samplesheet_assembly.csv \
    --submission_study PRJEB98843 \
    --test_upload false \
-   --webincli_submit true \
+   --webincli_mode submit \
    --outdir results/live_assembly
 ```
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -145,6 +145,7 @@ process {
     //
 
     withName: 'GENOME_UPLOAD' {
+        ext.args = "--force" // ensures that ENA metadata is re-downloaded even if cache exists
         publishDir = [
             path: { "${params.outdir}/${params.mode}/upload/manifests" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -162,10 +162,6 @@ process {
         ]
     }
 
-    withName: 'GENERATE_ASSEMBLY_MANIFEST|REGISTERSTUDY' {
-        ext.args = { params.test_upload ? "--test" : "" }
-    }
-
     withName: 'ENA_WEBIN_CLI_DOWNLOAD|REGISTERSTUDY|GENERATE_ASSEMBLY_MANIFEST' {
         publishDir = [
             enabled: false

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -176,7 +176,7 @@ The `GENOMESUBMIT` workflow uses `CheckM2` and `CAT_pack` that require specializ
 You can either provide pre-existing databases or let the pipeline prepare them during execution.
 
 - `CheckM2`:
-  - provide the path to local database with `--checkm2_db`, otherwise the pipeline downloads version specified with `--checkm2_db_zenodo_id` (by default `14897628`).
+  - provide the path to local database with `--checkm2_db`, otherwise the pipeline downloads version specified with `--checkm2_db_download_id` (by default `14897628`).
 
 - `CAT_pack`:
   - provide the path to local database (containing `tax/` and `db/` folders or `tar.gz` archive) with `--cat_db`, otherwise the pipeline constructs version specified with `--cat_db_download_id` (by default `nr`).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -214,10 +214,10 @@ Key parameters:
 | `--submission_study` | ENA study accession (PRJ/ERP) to submit the data to. For metagenomic assemblies, this is the paper's ENA Assembly Project accession. |
 | `--centre_name`      | Name of the submitter's organisation.                                                                                                |
 | `--test_upload`      | Submit to the ENA TEST server instead of the LIVE server.                                                                            |
-| `--webincli_submit`  | If `true`, submit to ENA. If `false`, validate the submission without uploading.                                                     |
+| `--webincli_mode`    | Webin-CLI mode for ENA interaction: `submit` uploads data, `validate` performs validation only.                                      |
 | `--upload_tpa`       | Mark assemblies as third party assemblies when required.                                                                             |
 
-Validation example for `mags` run with docker:
+Test example for `mags` run with docker:
 
 ```bash
 nextflow run nf-core/seqsubmit \
@@ -226,12 +226,12 @@ nextflow run nf-core/seqsubmit \
     --input assets/samplesheet_genomes.csv \
     --submission_study <your_study> \
     --centre_name TEST_CENTER \
-    --webincli_submit true \
+    --webincli_mode submit \
     --test_upload true \
     --outdir results/validate_mags
 ```
 
-Validation example for `metagenomic_assemblies` run with docker:
+Test example for `metagenomic_assemblies` run with docker:
 
 ```bash
 nextflow run nf-core/seqsubmit \
@@ -240,7 +240,7 @@ nextflow run nf-core/seqsubmit \
     --input assets/samplesheet_assembly.csv \
     --submission_study <your_study> \
     --centre_name TEST_CENTER \
-    --webincli_submit true \
+    --webincli_mode submit \
     --test_upload true \
     --outdir results/validate_assemblies
 ```

--- a/main.nf
+++ b/main.nf
@@ -55,7 +55,7 @@ workflow NFCORE_SEQSUBMIT {
             params.upload_tpa,
             params.test_upload,
             params.webin_cli_version,
-            params.webincli_submit
+            params.webincli_mode
         )
         ch_multiqc_report = GENOMESUBMIT.out.multiqc_report
     } else if (params.mode == "metagenomic_assemblies") {
@@ -66,7 +66,7 @@ workflow NFCORE_SEQSUBMIT {
             params.upload_tpa,
             params.test_upload,
             params.webin_cli_version,
-            params.webincli_submit
+            params.webincli_mode
         )
         ch_multiqc_report = ASSEMBLYSUBMIT.out.multiqc_report
     }

--- a/main.nf
+++ b/main.nf
@@ -42,12 +42,31 @@ workflow NFCORE_SEQSUBMIT {
     if (params.mode == "mags" || params.mode == "bins") {
         GENOMESUBMIT (
             samplesheet,
-            params.mode
+            params.mode,
+            params.submission_study,
+            params.study_metadata,
+            params.trna_limit,
+            params.rrna_limit,
+            params.checkm2_db,
+            params.checkm2_db_download_id,
+            params.cat_db,
+            params.cat_db_download_id,
+            params.centre_name,
+            params.upload_tpa,
+            params.test_upload,
+            params.webin_cli_version,
+            params.webincli_submit
         )
         ch_multiqc_report = GENOMESUBMIT.out.multiqc_report
     } else if (params.mode == "metagenomic_assemblies") {
         ASSEMBLYSUBMIT (
-            samplesheet
+            samplesheet,
+            params.submission_study,
+            params.study_metadata,
+            params.upload_tpa,
+            params.test_upload,
+            params.webin_cli_version,
+            params.webincli_submit
         )
         ch_multiqc_report = ASSEMBLYSUBMIT.out.multiqc_report
     }

--- a/modules/local/count_rna/main.nf
+++ b/modules/local/count_rna/main.nf
@@ -11,6 +11,8 @@ process COUNT_RNA {
 
     input:
     tuple val(meta), path(trnas_stats), path(rrna_gff)
+    val min_trna_count
+    val min_rrna_percentage
 
     output:
     tuple val(meta), path("*rna_decision.tsv"), emit: rna_decision
@@ -22,8 +24,8 @@ process COUNT_RNA {
         --trna ${trnas_stats} \\
         --rrna ${rrna_gff} \\
         --name ${meta.id} \\
-        --trna-limit ${params.trna_limit} \\
-        --rrna-limit ${params.rrna_limit} \\
+        --trna-limit ${min_trna_count} \\
+        --rrna-limit ${min_rrna_percentage} \\
         --output ${meta.id}_rna_decision.tsv
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/count_rna/meta.yml
+++ b/modules/local/count_rna/meta.yml
@@ -30,6 +30,12 @@ input:
       type: file
       description: rRNA annotation file from barrnap (GFF3 format)
       pattern: "*.gff"
+  - min_trna_count:
+      type: value
+      description: Minimum required number of tRNA genes.
+  - min_rrna_percentage:
+      type: value
+      description: Minimum required percentage coverage for each rRNA subunit.
 
 output:
   - meta:

--- a/modules/local/count_rna/tests/main.nf.test
+++ b/modules/local/count_rna/tests/main.nf.test
@@ -16,6 +16,8 @@ nextflow_process {
                     file("$moduleDir/tests/data/ecoli.stats", checkIfExists: true),
                     file("$moduleDir/tests/data/ecoli_bac.gff", checkIfExists: true)
                 ]
+                input[1] = 18
+                input[2] = 80
                 """
             }
         }
@@ -49,6 +51,8 @@ nextflow_process {
                     file("$moduleDir/tests/data/ecoli.stats", checkIfExists: true),
                     file("$moduleDir/tests/data/ecoli_bac.gff", checkIfExists: true)
                 ]
+                input[1] = 18
+                input[2] = 80
                 """
             }
         }

--- a/modules/local/ena_webin_cli_wrapper/main.nf
+++ b/modules/local/ena_webin_cli_wrapper/main.nf
@@ -12,7 +12,7 @@ process ENA_WEBIN_CLI_WRAPPER {
     tuple val(meta), path(submission_item), path(manifest)
     path(webin_cli_jar)
     val test_upload
-    val webincli_submit
+    val webincli_mode
 
     output:
     tuple val(meta), path("*_accessions.tsv"),  emit: accessions
@@ -22,7 +22,6 @@ process ENA_WEBIN_CLI_WRAPPER {
     def args               = task.ext.args   ?: ""
     def prefix             = task.ext.prefix ?: "${meta.id}"
     def test_flag          = test_upload     ? "--test" : ""
-    def submit_or_validate = webincli_submit ? "--mode submit": "--mode validate"
 
     """
     # change FASTA path in manifest to current workdir
@@ -33,7 +32,7 @@ process ENA_WEBIN_CLI_WRAPPER {
       -m ${prefix}_updated_manifest.manifest \\
       -o ${prefix}_accessions.tsv \\
       --webin-cli-jar ${webin_cli_jar} \\
-      ${submit_or_validate} \\
+      --mode ${webincli_mode} \\
       ${test_flag} \\
       ${args}
 

--- a/modules/local/ena_webin_cli_wrapper/main.nf
+++ b/modules/local/ena_webin_cli_wrapper/main.nf
@@ -11,16 +11,18 @@ process ENA_WEBIN_CLI_WRAPPER {
     input:
     tuple val(meta), path(submission_item), path(manifest)
     path(webin_cli_jar)
+    val test_upload
+    val webincli_submit
 
     output:
     tuple val(meta), path("*_accessions.tsv"),  emit: accessions
     path "versions.yml",                        emit: versions
 
     script:
-    def args               = task.ext.args          ?: ""
-    def prefix             = task.ext.prefix        ?: "${meta.id}"
-    def test_flag          = params.test_upload     ? "--test" : ""
-    def submit_or_validate = params.webincli_submit ? "--mode submit": "--mode validate"
+    def args               = task.ext.args   ?: ""
+    def prefix             = task.ext.prefix ?: "${meta.id}"
+    def test_flag          = test_upload     ? "--test" : ""
+    def submit_or_validate = webincli_submit ? "--mode submit": "--mode validate"
 
     """
     # change FASTA path in manifest to current workdir

--- a/modules/local/ena_webin_cli_wrapper/meta.yml
+++ b/modules/local/ena_webin_cli_wrapper/meta.yml
@@ -35,9 +35,9 @@ input:
   - - test_upload:
         type: value
         description: Whether to run ENA Webin-CLI in test mode.
-  - - webincli_submit:
+  - - webincli_mode:
         type: value
-        description: Whether to submit (`true`) or only validate (`false`).
+        description: "Webin-CLI mode. Allowed values: `submit` or `validate`."
 
 output:
   - accessions:

--- a/modules/local/ena_webin_cli_wrapper/meta.yml
+++ b/modules/local/ena_webin_cli_wrapper/meta.yml
@@ -35,7 +35,7 @@ input:
   - - test_upload:
         type: value
         description: Whether to run ENA Webin-CLI in test mode.
-    - webincli_submit:
+  - - webincli_submit:
         type: value
         description: Whether to submit (`true`) or only validate (`false`).
 

--- a/modules/local/ena_webin_cli_wrapper/meta.yml
+++ b/modules/local/ena_webin_cli_wrapper/meta.yml
@@ -31,19 +31,32 @@ input:
         type: file
         description: |
           The Webin-CLI JAR file downloaded by ena_webin_cli_download.
-          pattern: "webin-cli-*.jar"
+        pattern: "webin-cli-*.jar"
+  - - test_upload:
+        type: value
+        description: Whether to run ENA Webin-CLI in test mode.
+    - webincli_submit:
+        type: value
+        description: Whether to submit (`true`) or only validate (`false`).
 
 output:
-  - - accessions:
-        type: file
-        description: |
-          TSV file containing the accession assigned by ENA for the submitted item.
-          File has two columns: "alias" and "accession".
-  - - versions:
-    - "versions.yml":
-        type: file
-        description: File containing software versions.
-        pattern: "versions.yml"
+  - accessions:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information.
+            e.g. `[ id:'sample1' ]`
+      - "*_accessions.tsv":
+          type: file
+          description: |
+            TSV file containing the accession assigned by ENA for the submitted item.
+            File has two columns: "alias" and "accession".
+          pattern: "*_accessions.tsv"
+  - versions:
+      - "versions.yml":
+          type: file
+          description: File containing software versions.
+          pattern: "versions.yml"
 
 authors:
   - "@KateSakharova"

--- a/modules/local/ena_webin_cli_wrapper/nextflow.config
+++ b/modules/local/ena_webin_cli_wrapper/nextflow.config
@@ -1,7 +1,7 @@
 params {
     // Use ENA test server and validate only (no actual submission)
     test_upload     = true
-    webincli_submit = false
+    webincli_mode   = "validate"
 }
 
 process {

--- a/modules/local/generate_assembly_manifest/main.nf
+++ b/modules/local/generate_assembly_manifest/main.nf
@@ -7,6 +7,7 @@ process GENERATE_ASSEMBLY_MANIFEST {
     input:
     tuple val(meta), path(assembly_fasta), path(data_csv)
     val(assembly_study)
+    val(is_tpa)
 
     output:
     tuple val(meta), path("${assembly_study}_upload/*.manifest") , emit: manifest
@@ -18,7 +19,7 @@ process GENERATE_ASSEMBLY_MANIFEST {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def tpa = params.upload_tpa ? "--tpa" : ""
+    def tpa = is_tpa ? "--tpa" : ""
     """
     assembly_manifest \\
         --study ${assembly_study} \\

--- a/modules/local/generate_assembly_manifest/main.nf
+++ b/modules/local/generate_assembly_manifest/main.nf
@@ -8,6 +8,7 @@ process GENERATE_ASSEMBLY_MANIFEST {
     tuple val(meta), path(assembly_fasta), path(data_csv)
     val(assembly_study)
     val(is_tpa)
+    val(test_upload)
 
     output:
     tuple val(meta), path("${assembly_study}_upload/*.manifest") , emit: manifest
@@ -20,6 +21,7 @@ process GENERATE_ASSEMBLY_MANIFEST {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def tpa = is_tpa ? "--tpa" : ""
+    def test_flag = test_upload ? "--test" : ""
     """
     assembly_manifest \\
         --study ${assembly_study} \\
@@ -27,6 +29,7 @@ process GENERATE_ASSEMBLY_MANIFEST {
         --assembly_study ${assembly_study} \\
         --output-dir "." \\
         ${tpa} \\
+        ${test_flag} \\
         ${args}
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/generate_assembly_manifest/meta.yml
+++ b/modules/local/generate_assembly_manifest/meta.yml
@@ -31,6 +31,9 @@ input:
         description: |
           Pre-existing study ID to submit to if available.
           Must exist in the webin account.
+    - is_tpa:
+        type: value
+        description: Whether assembly being submitted is a TPA (Third Party Annotation).
 
 output:
   - meta:

--- a/modules/local/generate_assembly_manifest/meta.yml
+++ b/modules/local/generate_assembly_manifest/meta.yml
@@ -34,6 +34,9 @@ input:
     - is_tpa:
         type: value
         description: Whether assembly being submitted is a TPA (Third Party Annotation).
+    - test_upload:
+        type: value
+        description: Whether generated manifests are going to be submitted in test mode.
 
 output:
   - meta:

--- a/modules/local/generate_assembly_manifest/tests/main.nf.test
+++ b/modules/local/generate_assembly_manifest/tests/main.nf.test
@@ -18,6 +18,7 @@ nextflow_process {
                     file(params.pipelines_testdata_base_path + "/samplesheets/samplesheet_generatemanifest.csv", checkIfExists: true)
                 ]
                 input[1] = "PRJ12345"
+                input[2] = false
                 """
 
             }
@@ -62,6 +63,7 @@ nextflow_process {
                     file('test_samplesheet_generatemanifest.csv')
                 ]
                 input[1] = "PRJ12345"
+                input[2] = false
                 """
             }
         }

--- a/modules/local/generate_assembly_manifest/tests/main.nf.test
+++ b/modules/local/generate_assembly_manifest/tests/main.nf.test
@@ -19,6 +19,7 @@ nextflow_process {
                 ]
                 input[1] = "PRJ12345"
                 input[2] = false
+                input[3] = true
                 """
 
             }
@@ -64,6 +65,7 @@ nextflow_process {
                 ]
                 input[1] = "PRJ12345"
                 input[2] = false
+                input[3] = true
                 """
             }
         }

--- a/modules/local/genome_upload/main.nf
+++ b/modules/local/genome_upload/main.nf
@@ -9,6 +9,10 @@ process GENOME_UPLOAD {
     path(table_for_upload)
     val(mags_or_bins_flag)
     val(submission_study)
+    val(centre_name)
+    val(is_tpa)
+    val(upload_force)
+    val(test_upload)
 
     output:
     path "results/{MAG,bin}_upload/manifests*/*.manifest"      , emit: manifests
@@ -22,16 +26,16 @@ process GENOME_UPLOAD {
     task.ext.when == null || task.ext.when
 
     script:
-    def args     = task.ext.args         ?: ''
-    def tpa      = params.upload_tpa     ? "--tpa"  : ""
-    def force    = params.upload_force   ? "--force"  : ""
-    def mode     = (!params.test_upload) ? "--live" : ""
+    def args     = task.ext.args  ?: ''
+    def tpa      = is_tpa         ? "--tpa"  : ""
+    def force    = upload_force   ? "--force"  : ""
+    def mode     = (!test_upload) ? "--live" : ""
 
     """
     genome_upload \\
-        -u $submission_study \\
+        -u ${submission_study} \\
         --genome_info ${table_for_upload} \\
-        --centre_name $params.centre_name \\
+        --centre_name ${centre_name} \\
         --${mags_or_bins_flag} \\
         ${tpa} \\
         ${force} \\

--- a/modules/local/genome_upload/main.nf
+++ b/modules/local/genome_upload/main.nf
@@ -11,7 +11,6 @@ process GENOME_UPLOAD {
     val(submission_study)
     val(centre_name)
     val(is_tpa)
-    val(upload_force)
     val(test_upload)
 
     output:
@@ -28,7 +27,6 @@ process GENOME_UPLOAD {
     script:
     def args     = task.ext.args  ?: ''
     def tpa      = is_tpa         ? "--tpa"  : ""
-    def force    = upload_force   ? "--force"  : ""
     def mode     = (!test_upload) ? "--live" : ""
 
     """
@@ -38,7 +36,6 @@ process GENOME_UPLOAD {
         --centre_name ${centre_name} \\
         --${mags_or_bins_flag} \\
         ${tpa} \\
-        ${force} \\
         ${mode} \\
         --out results \\
         ${args}

--- a/modules/local/genome_upload/meta.yml
+++ b/modules/local/genome_upload/meta.yml
@@ -33,9 +33,6 @@ input:
   - is_tpa:
       type: value
       description: Whether genomes are submitted as TPA (Third Party Annotation).
-  - upload_force:
-      type: value
-      description: Whether to force rewrite existing cache of ENA metadata.
   - test_upload:
       type: value
       description: Whether to run in ENA test mode.

--- a/modules/local/genome_upload/meta.yml
+++ b/modules/local/genome_upload/meta.yml
@@ -13,11 +13,6 @@ tools:
       documentation: https://github.com/EBI-Metagenomics/genome_uploader
       licence: ["Apache License"]
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information.
-        e.g. [ id:'test', single_end:false ]
   - table_for_upload:
       type: file
       description: |
@@ -26,16 +21,29 @@ input:
       type: file
       description: File in FASTA format containing targeted mag/bin/assembly for submission
       pattern: "*.{fasta,fna,fas,fa}*"
+  - mags_or_bins_flag:
+      type: value
+      description: Upload mode selector. Expected values are `mags` or `bins`.
+  - submission_study:
+      type: value
+      description: ENA study accession used for submission.
+  - centre_name:
+      type: value
+      description: Submitting centre name required by ENA.
+  - is_tpa:
+      type: value
+      description: Whether genomes are submitted as TPA (Third Party Annotation).
+  - upload_force:
+      type: value
+      description: Whether to force rewrite existing cache of ENA metadata.
+  - test_upload:
+      type: value
+      description: Whether to run in ENA test mode.
 
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
   - manifests:
       type: file
-      description: Maniseft file required for submission with webin-cli
+      description: Manifest file required for submission with webin-cli
       pattern: "*.manifest"
   - ena_upload_backup_json:
       type: file

--- a/modules/local/registerstudy/main.nf
+++ b/modules/local/registerstudy/main.nf
@@ -13,6 +13,7 @@ process REGISTERSTUDY {
 
     input:
     tuple val(meta), path(study_metadata)
+    val(test_upload)
 
     output:
     tuple val(meta), path("*_accessions.json"), emit: accessions
@@ -22,12 +23,14 @@ process REGISTERSTUDY {
     task.ext.when == null || task.ext.when
 
     script:
-    def args   = task.ext.args   ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args      = task.ext.args   ?: ''
+    def prefix    = task.ext.prefix ?: "${meta.id}"
+    def test_flag = test_upload     ? "--test" : ""
     """
     submit_study.py \\
         --input ${study_metadata} \\
         --output ${prefix}_accessions.json \\
+        ${test_flag} \\
         ${args}
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/registerstudy/meta.yml
+++ b/modules/local/registerstudy/meta.yml
@@ -39,6 +39,9 @@ input:
           JSON may be a plain list of dicts or a single dict of study records.
           Required fields per record: study_title, alias.
         pattern: "*.{json,csv,tsv}"
+  - - test_upload:
+        type: value
+        description: Whether to submit to the ENA test server (`true`) instead of production.
 
 output:
   - accessions:

--- a/modules/local/registerstudy/tests/main.nf.test
+++ b/modules/local/registerstudy/tests/main.nf.test
@@ -16,6 +16,7 @@ nextflow_process {
                     [ id:'example_study' ],
                     file("$projectDir/assets/study_metadata.json", checkIfExists: true)
                 ]
+                input[1] = true
                 """
             }
         }
@@ -39,6 +40,7 @@ nextflow_process {
                     [ id:'example_study_tsv' ],
                     file("$projectDir/assets/study_metadata.tsv", checkIfExists: true)
                 ]
+                input[1] = true
                 """
             }
         }
@@ -63,6 +65,7 @@ nextflow_process {
                     [ id:'example_study' ],
                     file("$projectDir/assets/study_metadata.json", checkIfExists: true)
                 ]
+                input[1] = false
                 """
             }
         }

--- a/modules/local/registerstudy/tests/main.nf.test
+++ b/modules/local/registerstudy/tests/main.nf.test
@@ -65,7 +65,7 @@ nextflow_process {
                     [ id:'example_study' ],
                     file("$projectDir/assets/study_metadata.json", checkIfExists: true)
                 ]
-                input[1] = false
+                input[1] = true
                 """
             }
         }

--- a/modules/local/registerstudy/tests/nextflow.config
+++ b/modules/local/registerstudy/tests/nextflow.config
@@ -6,12 +6,6 @@
 // no HTTP calls are made. For real submission tests, replace with secrets:
 //   env { ENA_WEBIN = secrets.WEBIN_ACCOUNT; ENA_WEBIN_PASSWORD = secrets.WEBIN_PASSWORD }
 
-process {
-    withName: REGISTERSTUDY {
-        ext.args = '--test'
-    }
-}
-
 env {
     ENA_WEBIN          = secrets.ENA_WEBIN
     ENA_WEBIN_PASSWORD = secrets.ENA_WEBIN_PASSWORD

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,7 +26,7 @@ params {
 
     // checkm2: completeness and contamination
     checkm2_db                    = null
-    checkm2_db_zenodo_id          = 14897628
+    checkm2_db_download_id        = 14897628
 
     // NCBI taxonomy
     cat_db                        = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,7 +17,7 @@ params {
     centre_name                   = null
     upload_tpa                    = false
     test_upload                   = true
-    webincli_submit               = true
+    webincli_mode                 = "submit"
     webin_cli_version             = "9.0.3"
 
     // rna detection

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,8 +16,6 @@ params {
     submission_study              = null
     centre_name                   = null
     upload_tpa                    = false
-    // TODO: remove this parameter because it will never be used, and update the genome_uploader module accordingly
-    upload_force                  = true
     test_upload                   = true
     webincli_submit               = true
     webin_cli_version             = "9.0.3"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -97,8 +97,8 @@
                     "description": "Path to pre-downloaded checkm2 database",
                     "fa_icon": "fas fa-users-cog"
                 },
-                "checkm2_db_zenodo_id": {
-                    "type": "number",
+                "checkm2_db_download_id": {
+                    "type": "integer",
                     "description": "Zenodo ID for checkm2 database download",
                     "default": 14897628,
                     "fa_icon": "fas fa-users-cog"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -292,12 +292,6 @@
                     "default": true,
                     "help": "Use that flag for development purposes or for validation of your submissions. Submission would be done to TEST ENA server instead of LIVE server. TEST server holds data 24h and removes afterwords. LIVE server does not have option to modify your submission, you can only suppress data and re-upload"
                 },
-                "upload_force": {
-                    "type": "boolean",
-                    "description": "Enables force mode for genome_uploader (used for MAGs/BINs submission)",
-                    "default": true,
-                    "help": "Forces reset of bin/MAG sample xmls generation. This is useful if you changed something in your tsv table, or if ENA metadata haven't been downloaded correctly (you can check this in ENA_backup.json). Default: true"
-                },
                 "submission_study": {
                     "type": "string",
                     "description": "ENA study accession (PRJ/ERP) to submit the data to",
@@ -319,7 +313,7 @@
                 },
                 "webin_cli_version": {
                     "type": "string",
-                    "description": "Version of webon-cli.jar to use for submission",
+                    "description": "Version of webin-cli.jar to use for submission",
                     "default": "9.0.3",
                     "help": "Check version https://github.com/enasequence/webin-cli"
                 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -305,11 +305,12 @@
                     "help_text": "File containing study metadata fields (required: study_title and alias, optional: study_abstract, existing_study_type, etc.). Used by REGISTERSTUDY to create a new study in ENA when no existing submission_study accession is given.",
                     "fa_icon": "fas fa-file-alt"
                 },
-                "webincli_submit": {
-                    "type": "boolean",
-                    "description": "Submit or validate",
-                    "default": true,
-                    "help": "Flag to run submission or validation. Submission (true) will run upload of data with ena-webin-cli. Validation (false) validates correctness of input files, it does not do submission. Default: true (submit)"
+                "webincli_mode": {
+                    "type": "string",
+                    "description": "Webin-CLI mode of operation",
+                    "default": "submit",
+                    "enum": ["submit", "validate"],
+                    "help": "Controls ENA Webin-CLI mode. Use `submit` to upload data or `validate` to run validation only. Default: submit."
                 },
                 "webin_cli_version": {
                     "type": "string",

--- a/subworkflows/local/genome_evaluation.nf
+++ b/subworkflows/local/genome_evaluation.nf
@@ -43,7 +43,6 @@ workflow GENOME_EVALUATION {
         .map { _count, _meta, _fasta, db_meta, db_id -> [db_meta, db_id] }
 
     CHECKM2_DATABASEDOWNLOAD(ch_download_trigger)
-    ch_versions = ch_versions.mix( CHECKM2_DATABASEDOWNLOAD.out.versions )
 
     // Combine db sources - one of these channels will be empty depending on inputs
     ch_db = ch_checkm2_db.mix(CHECKM2_DATABASEDOWNLOAD.out.database).first()
@@ -56,11 +55,9 @@ workflow GENOME_EVALUATION {
         ch_fasta,
         ch_db,
     )
-    ch_versions = ch_versions.mix( CHECKM2_PREDICT.out.versions )
 
     emit:
     genome_evaluation = CHECKM2_PREDICT.out.checkm2_tsv  // channel: [ val(meta), path(tsv) ]
     stats_versions    = CHECKM2_PREDICT.out.versions_checkm2_predict
-    versions          = ch_versions
 
 }

--- a/subworkflows/local/genome_evaluation.nf
+++ b/subworkflows/local/genome_evaluation.nf
@@ -22,8 +22,8 @@ workflow GENOME_EVALUATION {
     take:
     ch_fasta                // channel: [ val(meta), path(fasta) ]
     ch_checkm2_db           // channel: [ val(meta), path(db) ] - pre-built db as directory
-                            //          provide channel.empty() to trigger automatic download via ch_checkm2_db_zenodo_id
-    ch_checkm2_db_zenodo_id // channel: [ val(meta), val(db_id) ] - db ID for CHECKM2_DATABASEDOWNLOAD (e.g. '1234567')
+                            //          provide channel.empty() to trigger automatic download via ch_checkm2_db_download_id
+    ch_checkm2_db_download_id // channel: [ val(meta), val(db_id) ] - db ID for CHECKM2_DATABASEDOWNLOAD (e.g. '1234567')
                             //          only used if ch_checkm2_db is empty
 
     main:
@@ -39,7 +39,7 @@ workflow GENOME_EVALUATION {
         .count()
         .filter { count -> count == 0 }  // Only proceed if ch_checkm2_db is empty
         .combine(ch_fasta.first())
-        .combine(ch_checkm2_db_zenodo_id)
+        .combine(ch_checkm2_db_download_id)
         .map { _count, _meta, _fasta, db_meta, db_id -> [db_meta, db_id] }
 
     CHECKM2_DATABASEDOWNLOAD(ch_download_trigger)

--- a/subworkflows/local/genome_evaluation.nf
+++ b/subworkflows/local/genome_evaluation.nf
@@ -20,7 +20,11 @@ include { CHECKM2_PREDICT          } from '../../modules/nf-core/checkm2/predict
 workflow GENOME_EVALUATION {
 
     take:
-    ch_fasta   // channel: [ val(meta), path(fasta) ]
+    ch_fasta                // channel: [ val(meta), path(fasta) ]
+    ch_checkm2_db           // channel: [ val(meta), path(db) ] - pre-built db as directory
+                            //          provide channel.empty() to trigger automatic download via ch_checkm2_db_zenodo_id
+    ch_checkm2_db_zenodo_id // channel: [ val(meta), val(db_id) ] - db ID for CHECKM2_DATABASEDOWNLOAD (e.g. '1234567')
+                            //          only used if ch_checkm2_db is empty
 
     main:
     ch_versions = channel.empty()
@@ -29,24 +33,20 @@ workflow GENOME_EVALUATION {
     // Database preparation
     //
 
-    if (!params.checkm2_db || !file(params.checkm2_db).exists()) {
-        // Conditional download: only trigger if ch_fasta has items
-        ch_download_trigger = ch_fasta
-            .map { _meta, _fasta -> params.checkm2_db_zenodo_id }
-            .first()  // Only need one trigger regardless of how many fasta files
+    // Download and prepare db from scratch if no pre-built db provided
+    // Only trigger if ch_fasta has items
+    ch_download_trigger = ch_checkm2_db
+        .count()
+        .filter { count -> count == 0 }  // Only proceed if ch_checkm2_db is empty
+        .combine(ch_fasta.first())
+        .combine(ch_checkm2_db_zenodo_id)
+        .map { _count, _meta, _fasta, db_meta, db_id -> [db_meta, db_id] }
 
-        CHECKM2_DATABASEDOWNLOAD(ch_download_trigger)
-        ch_checkm2_db = CHECKM2_DATABASEDOWNLOAD.out.database
-    }
-    else {
-        // Use existing database
-        ch_checkm2_db = channel.of(
-            [
-                [id: "checkm2_db"],
-                file(params.checkm2_db),
-            ]
-        )
-    }
+    CHECKM2_DATABASEDOWNLOAD(ch_download_trigger)
+    ch_versions = ch_versions.mix( CHECKM2_DATABASEDOWNLOAD.out.versions )
+
+    // Combine db sources - one of these channels will be empty depending on inputs
+    ch_db = ch_checkm2_db.mix(CHECKM2_DATABASEDOWNLOAD.out.database).first()
 
     //
     // Genome evaluation
@@ -54,11 +54,13 @@ workflow GENOME_EVALUATION {
 
     CHECKM2_PREDICT(
         ch_fasta,
-        ch_checkm2_db,
+        ch_db,
     )
+    ch_versions = ch_versions.mix( CHECKM2_PREDICT.out.versions )
 
     emit:
     genome_evaluation = CHECKM2_PREDICT.out.checkm2_tsv  // channel: [ val(meta), path(tsv) ]
     stats_versions    = CHECKM2_PREDICT.out.versions_checkm2_predict
+    versions          = ch_versions
 
 }

--- a/subworkflows/local/rna_detection.nf
+++ b/subworkflows/local/rna_detection.nf
@@ -20,7 +20,9 @@ include { TRNASCANSE     } from '../../modules/nf-core/trnascanse'
 
 workflow RNA_DETECTION {
     take:
-    fasta
+    fasta                // channel: [ val(meta), path(fasta) ]
+    min_trna_count       // val: int - minimum number of tRNAs required to pass MIMAG standard (e.g. 18)
+    min_rrna_percentage  // val: float - minimum percentage of rRNA genes required to pass MIMAG standard (e.g. 75)
 
     main:
 
@@ -36,7 +38,9 @@ workflow RNA_DETECTION {
     ch_versions = ch_versions.mix( TRNASCANSE.out.versions )
 
     COUNT_RNA(
-        TRNASCANSE.out.stats.join(BARRNAP.out.gff)
+        TRNASCANSE.out.stats.join(BARRNAP.out.gff),
+        min_trna_count,
+        min_rrna_percentage
     )
     ch_versions = ch_versions.mix( COUNT_RNA.out.versions )
 

--- a/workflows/assemblysubmit.nf
+++ b/workflows/assemblysubmit.nf
@@ -26,7 +26,13 @@ include { methodsDescriptionText          } from '../subworkflows/local/utils_nf
 workflow ASSEMBLYSUBMIT {
 
     take:
-    ch_samplesheet // channel: samplesheet read in from --input
+    ch_samplesheet       // channel: samplesheet read in from --input
+    submission_study     // val: accession of the study to submit to (optional)
+    study_metadata       // val: path to study metadata file for study creation (used if no submission_study provided)
+    upload_tpa           // val: upload as TPA (Third Party Annotation)
+    test_upload          // val: true for test upload mode
+    webin_cli_version    // val: WebinCLI tool version to download and use for submission
+    webincli_submit      // val: true to validate and submit via WebinCLI, false to only validate
 
     main:
     ch_versions = channel.empty()
@@ -146,13 +152,13 @@ workflow ASSEMBLYSUBMIT {
         }
 
     def study_accession_ch
-    if (params.submission_study) {
+    if (submission_study) {
         // Use provided study accession directly
-        study_accession_ch = channel.of(params.submission_study)
+        study_accession_ch = channel.of(submission_study)
     } else {
         // Register a new study using the study metadata file
         REGISTERSTUDY(
-            channel.of([[id: "study"], file(params.study_metadata)])
+            channel.of([[id: "study"], file(study_metadata)])
         )
         ch_versions = ch_versions.mix(REGISTERSTUDY.out.versions)
         study_accession_ch = REGISTERSTUDY.out.accessions
@@ -166,18 +172,18 @@ workflow ASSEMBLYSUBMIT {
     GENERATE_ASSEMBLY_MANIFEST(
         assemblies_with_coverage.join(assembly_metadata_csv),
         study_accession_ch.first(),
-        params.upload_tpa
+        upload_tpa
     )
 
     ENA_WEBIN_CLI_DOWNLOAD (
-        params.webin_cli_version
+        webin_cli_version
     )
 
     SUBMIT (
         assemblies_with_coverage.join(GENERATE_ASSEMBLY_MANIFEST.out.manifest),
         ENA_WEBIN_CLI_DOWNLOAD.out.webin_cli_jar,
-        params.test_upload,
-        params.webincli_submit
+        test_upload,
+        webincli_submit
     )
 
     //

--- a/workflows/assemblysubmit.nf
+++ b/workflows/assemblysubmit.nf
@@ -165,7 +165,8 @@ workflow ASSEMBLYSUBMIT {
     // Generate assembly manifest files and submit them to ENA
     GENERATE_ASSEMBLY_MANIFEST(
         assemblies_with_coverage.join(assembly_metadata_csv),
-        study_accession_ch.first()
+        study_accession_ch.first(),
+        params.upload_tpa
     )
 
     ENA_WEBIN_CLI_DOWNLOAD (

--- a/workflows/assemblysubmit.nf
+++ b/workflows/assemblysubmit.nf
@@ -174,7 +174,9 @@ workflow ASSEMBLYSUBMIT {
 
     SUBMIT (
         assemblies_with_coverage.join(GENERATE_ASSEMBLY_MANIFEST.out.manifest),
-        ENA_WEBIN_CLI_DOWNLOAD.out.webin_cli_jar
+        ENA_WEBIN_CLI_DOWNLOAD.out.webin_cli_jar,
+        params.test_upload,
+        params.webincli_submit
     )
 
     //

--- a/workflows/assemblysubmit.nf
+++ b/workflows/assemblysubmit.nf
@@ -32,7 +32,7 @@ workflow ASSEMBLYSUBMIT {
     upload_tpa           // val: upload as TPA (Third Party Annotation)
     test_upload          // val: true for test upload mode
     webin_cli_version    // val: WebinCLI tool version to download and use for submission
-    webincli_submit      // val: true to validate and submit via WebinCLI, false to only validate
+    webincli_mode        // val: either 'validate' or 'submit' to specify WebinCLI mode of operation
 
     main:
     ch_versions = channel.empty()
@@ -185,7 +185,7 @@ workflow ASSEMBLYSUBMIT {
         assemblies_with_coverage.join(GENERATE_ASSEMBLY_MANIFEST.out.manifest),
         ENA_WEBIN_CLI_DOWNLOAD.out.webin_cli_jar,
         test_upload,
-        webincli_submit
+        webincli_mode
     )
 
     //

--- a/workflows/assemblysubmit.nf
+++ b/workflows/assemblysubmit.nf
@@ -158,7 +158,8 @@ workflow ASSEMBLYSUBMIT {
     } else {
         // Register a new study using the study metadata file
         REGISTERSTUDY(
-            channel.of([[id: "study"], file(study_metadata)])
+            channel.of([[id: "study"], file(study_metadata)]),
+            test_upload
         )
         ch_versions = ch_versions.mix(REGISTERSTUDY.out.versions)
         study_accession_ch = REGISTERSTUDY.out.accessions
@@ -172,7 +173,8 @@ workflow ASSEMBLYSUBMIT {
     GENERATE_ASSEMBLY_MANIFEST(
         assemblies_with_coverage.join(assembly_metadata_csv),
         study_accession_ch.first(),
-        upload_tpa
+        upload_tpa,
+        test_upload
     )
 
     ENA_WEBIN_CLI_DOWNLOAD (

--- a/workflows/genomesubmit.nf
+++ b/workflows/genomesubmit.nf
@@ -288,7 +288,11 @@ workflow GENOMESUBMIT {
         fasta_updated_with_stats.map{meta, fasta -> fasta}.collect(),
         genome_metadata_csv,
         mags_or_bins_flag,     // mags or bins
-        study_accession_ch.first()
+        study_accession_ch.first(),
+        params.centre_name,
+        params.upload_tpa,
+        params.upload_force,
+        params.test_upload
     )
 
     // All manifests were generated in one run

--- a/workflows/genomesubmit.nf
+++ b/workflows/genomesubmit.nf
@@ -31,8 +31,21 @@ include { methodsDescriptionText            } from '../subworkflows/local/utils_
 workflow GENOMESUBMIT {
 
     take:
-    ch_samplesheet // channel: samplesheet read in from --input
-    mags_or_bins_flag
+    ch_samplesheet           // channel: samplesheet read in from --input
+    mags_or_bins_flag        // val: submission mode (mags or bins)
+    submission_study         // val: accession of the study to submit to (optional)
+    study_metadata           // val: path to study metadata file for study creation (used if no submission_study provided)
+    trna_limit               // val: tRNA count threshold
+    rrna_limit               // val: rRNA length percentage threshold
+    checkm2_db               // val: path to CheckM2 database
+    checkm2_db_download_id   // val: CheckM2 database download ID
+    cat_db                   // val: path to CAT database
+    cat_db_download_id       // val: CAT database download ID
+    centre_name              // val: submission centre name
+    upload_tpa               // val: upload as TPA (Third Party Annotation)
+    test_upload              // val: true for test upload mode
+    webin_cli_version        // val: WebinCLI tool version to download and use for submission
+    webincli_submit          // val: true to validate and submit via WebinCLI, false to only validate
 
     main:
 
@@ -130,8 +143,8 @@ workflow GENOMESUBMIT {
 
     RNA_DETECTION (
         branched_rna_results.rna_prediction_input,
-        params.trna_limit,
-        params.rrna_limit
+        trna_limit,
+        rrna_limit
     )
     ch_versions = ch_versions.mix( RNA_DETECTION.out.versions )
 
@@ -154,12 +167,12 @@ workflow GENOMESUBMIT {
     .set { branched_stats_results }
 
     // build input structures for CheckM2 DB depending on what provided as input
-    def checkm2_db_input = params.checkm2_db
-        ? channel.of( [['id': 'CHECKM2_DB'], file(params.checkm2_db)] )
+    def checkm2_db_input = checkm2_db
+        ? channel.of( [['id': 'CHECKM2_DB'], file(checkm2_db)] )
         : channel.empty()
 
-    def checkm2_db_id_input = (!params.checkm2_db && params.checkm2_db_download_id)
-        ? channel.of( [['id': 'CHECKM2_DB_id'], params.checkm2_db_download_id] )
+    def checkm2_db_id_input = (!checkm2_db && checkm2_db_download_id)
+        ? channel.of( [['id': 'CHECKM2_DB_id'], checkm2_db_download_id] )
         : channel.empty()
 
     GENOME_EVALUATION (
@@ -201,12 +214,12 @@ workflow GENOMESUBMIT {
     )
 
     // build input structures for CAT_DB depending on what provided as input
-    def cat_db_input = params.cat_db
-        ? channel.of( [['id': 'CAT_DB'], file(params.cat_db)] )
+    def cat_db_input = cat_db
+        ? channel.of( [['id': 'CAT_DB'], file(cat_db)] )
         : channel.empty()
 
-    def cat_db_id_input = (!params.cat_db && params.cat_db_download_id)
-        ? channel.of( [['id': 'CAT_DB_id'], params.cat_db_download_id] )
+    def cat_db_id_input = (!cat_db && cat_db_download_id)
+        ? channel.of( [['id': 'CAT_DB_id'], cat_db_download_id] )
         : channel.empty()
 
     FASTA_CLASSIFY_CATPACK (
@@ -278,11 +291,11 @@ workflow GENOMESUBMIT {
 
     // --------- Register study if accession not provided
     def study_accession_ch
-    if (params.submission_study) {
-        study_accession_ch = channel.of(params.submission_study)
+    if (submission_study) {
+        study_accession_ch = channel.of(submission_study)
     } else {
         REGISTERSTUDY(
-            channel.of([[id: "study"], file(params.study_metadata)])
+            channel.of([[id: "study"], file(study_metadata)])
         )
         ch_versions = ch_versions.mix(REGISTERSTUDY.out.versions)
         study_accession_ch = REGISTERSTUDY.out.accessions
@@ -298,16 +311,16 @@ workflow GENOMESUBMIT {
         genome_metadata_csv,
         mags_or_bins_flag,     // mags or bins
         study_accession_ch.first(),
-        params.centre_name,
-        params.upload_tpa,
-        params.test_upload
+        centre_name,
+        upload_tpa,
+        test_upload
     )
 
     // All manifests were generated in one run
     // Manifests should be separated into different channels using prefix as id
     manifests_ch = CREATE_MANIFESTS.out.manifests.flatten()
         .map { manifest ->
-            def prefix = params.test_upload ?
+            def prefix = test_upload ?
                 manifest.name.replaceAll(/_\d+\.manifest$/, '') :  // Remove extension and hash suffix appended in test mode
                 manifest.name.replaceAll(/\.manifest$/, '')        // Remove only extension in live mode
             def meta = [id: prefix]
@@ -325,14 +338,14 @@ workflow GENOMESUBMIT {
 
     // --------- Upload data to ENA
     ENA_WEBIN_CLI_DOWNLOAD (
-        params.webin_cli_version
+        webin_cli_version
     )
 
     SUBMIT (
         ch_combined,
         ENA_WEBIN_CLI_DOWNLOAD.out.webin_cli_jar,
-        params.test_upload,
-        params.webincli_submit
+        test_upload,
+        webincli_submit
     )
 
     //

--- a/workflows/genomesubmit.nf
+++ b/workflows/genomesubmit.nf
@@ -295,7 +295,8 @@ workflow GENOMESUBMIT {
         study_accession_ch = channel.of(submission_study)
     } else {
         REGISTERSTUDY(
-            channel.of([[id: "study"], file(study_metadata)])
+            channel.of([[id: "study"], file(study_metadata)]),
+            test_upload
         )
         ch_versions = ch_versions.mix(REGISTERSTUDY.out.versions)
         study_accession_ch = REGISTERSTUDY.out.accessions

--- a/workflows/genomesubmit.nf
+++ b/workflows/genomesubmit.nf
@@ -153,10 +153,19 @@ workflow GENOMESUBMIT {
         }
     .set { branched_stats_results }
 
+    // build input structures for CheckM2 DB depending on what provided as input
+    def checkm2_db_input = params.checkm2_db
+        ? channel.of( [['id': 'CHECKM2_DB'], file(params.checkm2_db)] )
+        : channel.empty()
+
+    def checkm2_db_id_input = (!params.checkm2_db && params.checkm2_db_download_id)
+        ? channel.of( [['id': 'CHECKM2_DB_id'], params.checkm2_db_download_id] )
+        : channel.empty()
+
     GENOME_EVALUATION (
         branched_stats_results.genome_evaluation_input,
-        params.checkm2_db,
-        params.checkm2_db_zenodo_id
+        checkm2_db_input,
+        checkm2_db_id_input
     )
 
     // Create a value channel with the version string

--- a/workflows/genomesubmit.nf
+++ b/workflows/genomesubmit.nf
@@ -129,7 +129,9 @@ workflow GENOMESUBMIT {
     .set { branched_rna_results }
 
     RNA_DETECTION (
-        branched_rna_results.rna_prediction_input
+        branched_rna_results.rna_prediction_input,
+        params.trna_limit,
+        params.rrna_limit
     )
     ch_versions = ch_versions.mix( RNA_DETECTION.out.versions )
 
@@ -152,7 +154,9 @@ workflow GENOMESUBMIT {
     .set { branched_stats_results }
 
     GENOME_EVALUATION (
-        branched_stats_results.genome_evaluation_input
+        branched_stats_results.genome_evaluation_input,
+        params.checkm2_db,
+        params.checkm2_db_zenodo_id
     )
 
     // Create a value channel with the version string
@@ -283,7 +287,7 @@ workflow GENOMESUBMIT {
     CREATE_MANIFESTS(
         fasta_updated_with_stats.map{meta, fasta -> fasta}.collect(),
         genome_metadata_csv,
-        params.mode,     // mags or bins
+        mags_or_bins_flag,     // mags or bins
         study_accession_ch.first()
     )
 

--- a/workflows/genomesubmit.nf
+++ b/workflows/genomesubmit.nf
@@ -318,7 +318,9 @@ workflow GENOMESUBMIT {
 
     SUBMIT (
         ch_combined,
-        ENA_WEBIN_CLI_DOWNLOAD.out.webin_cli_jar
+        ENA_WEBIN_CLI_DOWNLOAD.out.webin_cli_jar,
+        params.test_upload,
+        params.webincli_submit
     )
 
     //

--- a/workflows/genomesubmit.nf
+++ b/workflows/genomesubmit.nf
@@ -45,7 +45,7 @@ workflow GENOMESUBMIT {
     upload_tpa               // val: upload as TPA (Third Party Annotation)
     test_upload              // val: true for test upload mode
     webin_cli_version        // val: WebinCLI tool version to download and use for submission
-    webincli_submit          // val: true to validate and submit via WebinCLI, false to only validate
+    webincli_mode            // val: either 'validate' or 'submit' to specify WebinCLI mode of operation
 
     main:
 
@@ -346,7 +346,7 @@ workflow GENOMESUBMIT {
         ch_combined,
         ENA_WEBIN_CLI_DOWNLOAD.out.webin_cli_jar,
         test_upload,
-        webincli_submit
+        webincli_mode
     )
 
     //

--- a/workflows/genomesubmit.nf
+++ b/workflows/genomesubmit.nf
@@ -300,7 +300,6 @@ workflow GENOMESUBMIT {
         study_accession_ch.first(),
         params.centre_name,
         params.upload_tpa,
-        params.upload_force,
         params.test_upload
     )
 


### PR DESCRIPTION
<!--
# nf-core/seqsubmit pull request

Many thanks for contributing to nf-core/seqsubmit!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/seqsubmit/tree/master/.github/CONTRIBUTING.md)
-->

Resolves #43  

### What was done? 

- Inputs added to modules COUNT_RNA, ENA_WEBIN_CLI_WRAPPER, GENERATE_ASSEMBLY_MANIFEST, GENOME_UPLOAD and REGISTER_STUDY to supply params values. Corresponding nf-tests and meta.yml files updated accordingly. 

**Why?** According to nf-core standards modules should not use params directly. 

- Inputs added to subwf GENOME_EVALUATION, RNA_DETECTION and workflows ASSEMBLYSUBMIT, GENOMESUBMIT and main.nf to supply params values. 
 
**Why?** According to nf-core standards workflows should not use params directly. 

- removed `ext.args = { params.test_upload ? "--test" : "" }` from modules.conf for modules GENERATE_ASSEMBLY_MANIFEST and REGISTERSTUDY, now input `test_upload` is used instead

**Why?** For consistency with other modules.

- pipeline argument `--upload_force` removed. It controls either existing cache is used or rewritten during genome_uploader run. 

**Why?** Argument is not relevant in Nextflow, because genome_uploader always starts with empty workdir without existing cache. Can be confusing for the user. 

- `--checkm2_db_zenodo_id` renamed to `--checkm2_db_download_id` for consistency with `--cat_db_download_id`



## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/seqsubmit/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/seqsubmit _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).